### PR TITLE
fix(ci): revert change to semver

### DIFF
--- a/sam/ci/template.yaml
+++ b/sam/ci/template.yaml
@@ -21,7 +21,7 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:646794253159:applications/aws-sam-codepipeline-cd
-        SemanticVersion: 1.2.3
+        SemanticVersion: 1.1.0 #version of the ci application
       Parameters:
         GitHubOAuthToken: !Sub '{{resolve:secretsmanager:${GitHubOAuthTokenSecretId}}}'
         GitHubOwner: !Ref GitHubOwner


### PR DESCRIPTION
the semver in `sam/ci/template.yaml` is the version of the ci pipeline `aws-sam-codepipeline-cd` not the publisher itself - 1.1.0 is the latest version.